### PR TITLE
Add new executables mkpmap and pmapdump

### DIFF
--- a/src/rt/CMakeLists.txt
+++ b/src/rt/CMakeLists.txt
@@ -7,6 +7,9 @@ add_library(radiance
   m_mirror.c m_mist.c mx_func.c mx_data.c noise3.c normal.c o_face.c o_cone.c
   o_instance.c o_mesh.c p_data.c p_func.c preload.c raytrace.c renderopts.c
   source.c sphere.c srcobstr.c srcsupp.c srcsamp.c t_data.c t_func.c text.c
+  pmap.c pmapsrc.c pmapmat.c pmaprand.c pmapio.c 
+  pmapbias.c pmapparm.c pmapcontrib.c pmapamb.c pmapray.c pmapopt.c 
+  pmapdata.c pmapdiag.c pmaptype.c
   "${VERSION_FILE}" virtuals.c)
 
 if(WIN32)
@@ -28,6 +31,12 @@ target_link_libraries(lookamb rtrad)
 
 add_executable(rcontrib rcmain.c rcontrib.c rc2.c rc3.c)
 target_link_libraries(rcontrib radiance rtrad)
+
+add_executable(mkpmap mkpmap.c)
+target_link_libraries(mkpmap radiance rtrad)
+
+add_executable(pmapdump pmapdump.c pmaptype.c pmapparm.c)
+target_link_libraries(pmapdump radiance rtrad)
 
 set(targets_to_install lookamb radiance raycalls rtrace rpict rcontrib)
 


### PR DESCRIPTION
@rpg777 I think this is what you need.  On inspection of the Rmakefile it doesn't appear there is a new library but instead two new executable targets named mkpmap and pmapdump.  There are also many new files that appear to be added to the radiance library.  According to the diff you sent me, these files are those that you added to a new library named pmap.  My inspection of the Rmakefile indicated that this new library does not exist in the upstream radiance project, but if you want it, we can certainly carve it out and link it into the new executables.

*disclaimer I have no idea what any of this does.  Its just targets to me.  It does build though.