### PR TITLE
Change max gensky zenith to 89.999

### DIFF
--- a/src/gen/gensky.c
+++ b/src/gen/gensky.c
@@ -215,13 +215,13 @@ computesky(void)			/* compute sky parameters */
 		printf("# Solar altitude and azimuth: %.1f %.1f\n",
 				180./PI*altitude, 180./PI*azimuth);
 	}
-	if (!overcast && altitude > 87.*PI/180.) {
+	if (!overcast && altitude > 89.999*PI/180.) {
 		fprintf(stderr,
-"%s: warning - sun too close to zenith, reducing altitude to 87 degrees\n",
+"%s: warning - sun too close to zenith, reducing altitude to 89.999 degrees\n",
 				progname);
 		printf(
-"# warning - sun too close to zenith, reducing altitude to 87 degrees\n");
-		altitude = 87.*PI/180.;
+"# warning - sun too close to zenith, reducing altitude to 89.999 degrees\n");
+		altitude = 89.999*PI/180.;
 	}
 	sundir[0] = -sin(azimuth)*cos(altitude);
 	sundir[1] = -cos(azimuth)*cos(altitude);


### PR DESCRIPTION
Updated gensky to keep the sun position 0.001 degrees from the zenith instead of 3.0 degrees from the zenith. This 3 degree error causes inaccuracies in locations between the tropics where the sun can be truly directly overhead. A difference of 0.001 degrees is approximately the same as a 100 m offset in position at the equator, a 3 degree error is the equivalent of having the model be more than 330 km from where it should be. See [this Wikipedia chart](https://en.wikipedia.org/wiki/Decimal_degrees) for further information.